### PR TITLE
Add support for pretrained encoders and transformed data

### DIFF
--- a/simsity/preprocessing/_columnlist.py
+++ b/simsity/preprocessing/_columnlist.py
@@ -7,11 +7,9 @@ class ColumnLister(BaseEstimator, TransformerMixin):
 
     def __init__(self, column) -> None:
         self.column = column
-        self._is_fitted = False
 
     def fit(self, X, y) -> "ColumnLister":
         """Fits the estimator. No-op."""
-        self._is_fitted = True
         return self
 
     def transform(self, X) -> List[str]:

--- a/simsity/preprocessing/_columnlist.py
+++ b/simsity/preprocessing/_columnlist.py
@@ -7,9 +7,11 @@ class ColumnLister(BaseEstimator, TransformerMixin):
 
     def __init__(self, column) -> None:
         self.column = column
+        self._is_fitted = False
 
     def fit(self, X, y) -> "ColumnLister":
         """Fits the estimator. No-op."""
+        self._is_fitted = True
         return self
 
     def transform(self, X) -> List[str]:

--- a/simsity/service.py
+++ b/simsity/service.py
@@ -57,7 +57,6 @@ class Service:
         Arguments:
             n_neighbors: Number of neighbors to return.
             out: Output format. Can be either "list" or "dataframe".
-            data: Data which has already been transformed by the encoder.
             kwargs: Arguments to pass as the query.
         """
         if not self._trained:

--- a/simsity/service.py
+++ b/simsity/service.py
@@ -4,7 +4,7 @@ import pathlib
 import pandas as pd
 from joblib import dump, load
 from simsity import __version__
-
+import warnings
 
 class Service:
     """
@@ -38,10 +38,15 @@ class Service:
         subset = df
         if features:
             subset = df[features]
+
         self.storage = {i: r for i, r in enumerate(subset.to_dict(orient="records"))}
         
         if self._trained:
-            data = self.encoder.transform(subset)
+            try:
+                data = self.encoder.transform(subset)
+            except Exception as e:
+                warnings.warn("Encountered error using pretrained encoder. Are you sure it is trained?")
+                raise e
         else:
             data = self.encoder.fit_transform(subset)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,39 @@ def untrained_service():
         encoder=make_pipeline(ColumnLister(column="text"), CountVectorizer()),
         indexer=PyNNDescentIndexer(metric="euclidean", n_neighbors=2),
     )
+
+@pytest.fixture(scope="session")
+def pretrained_clinc_service():
+    """Create a service with a pretrained encoder"""
+    df_clinc = pd.read_csv("tests/data/clinc-data.csv")
+
+    pretrained_encoder = make_pipeline(ColumnLister(column="text"), CountVectorizer())
+    pretrained_encoder.fit(df_clinc)
+
+    pretrained_service_clinc = Service(
+        encoder=pretrained_encoder,
+        indexer=PyNNDescentIndexer(metric="euclidean", n_neighbors=2),
+    )
+
+    pretrained_service_clinc.train_from_dataf(df_clinc, features=["text"])
+
+    return pretrained_service_clinc
+
+
+@pytest.fixture(scope="session")
+def encoded_clinc_service():
+    """Create a service with the data already encoded"""
+    df_clinc = pd.read_csv("tests/data/clinc-data.csv")
+
+    pretrained_encoder = CountVectorizer()
+    data = pretrained_encoder.fit_transform(df_clinc["text"].values)
+
+    encoded_service_clinc = Service(
+        encoder=pretrained_encoder,
+        indexer=PyNNDescentIndexer(metric="euclidean", n_neighbors=2),
+    )
+
+    encoded_service_clinc.train_from_transformed_data(df_clinc, features=["text"], transformed_data=data)
+
+    return encoded_service_clinc
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,27 +58,11 @@ def pretrained_clinc_service():
     pretrained_service_clinc = Service(
         encoder=pretrained_encoder,
         indexer=PyNNDescentIndexer(metric="euclidean", n_neighbors=2),
+        refit=False
     )
 
     pretrained_service_clinc.train_from_dataf(df_clinc, features=["text"])
 
     return pretrained_service_clinc
 
-
-@pytest.fixture(scope="session")
-def encoded_clinc_service():
-    """Create a service with the data already encoded"""
-    df_clinc = pd.read_csv("tests/data/clinc-data.csv")
-
-    pretrained_encoder = CountVectorizer()
-    data = pretrained_encoder.fit_transform(df_clinc["text"].values)
-
-    encoded_service_clinc = Service(
-        encoder=pretrained_encoder,
-        indexer=PyNNDescentIndexer(metric="euclidean", n_neighbors=2),
-    )
-
-    encoded_service_clinc.train_from_transformed_data(df_clinc, features=["text"], transformed_data=data)
-
-    return encoded_service_clinc
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,8 +2,10 @@ import json
 import pytest
 import pathlib
 
+import pandas as pd
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import make_pipeline
+from sklearn.exceptions import NotFittedError
 
 from simsity.service import Service
 from simsity.preprocessing import SparseMinHasher
@@ -31,6 +33,20 @@ def test_query_raises_error_no_train2():
     )
     with pytest.raises(RuntimeError):
         service.query(text="give me directions", n_neighbors=100)
+
+
+def test_train_raises_error_no_fit():
+    """
+    You cannot have refit=False without a trained encoder.
+    """
+    df = pd.DataFrame(["give me directions"], columns=["text"])
+    service = Service(
+        indexer=PyNNDescentIndexer(metric="euclidean"), encoder=CountVectorizer(),
+        refit=False
+    )
+    # Since the encoder is a sklearn transformer it will throw a NotFittedError
+    with pytest.raises(NotFittedError):
+        service.train_from_dataf(df, features=["text"])
 
 
 def test_train_path_no_exists(tmpdir):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -39,3 +39,37 @@ def test_smoke_clinc(clinc_service, tmpdir):
     reloaded = Service.load(tmpdir)
 
     assert reloaded._trained
+
+
+def test_smoke_pretrained_clinc(pretrained_clinc_service, tmpdir):
+    """
+    Run a simple smoke test to ensure that the service with a pretrained encoder is working.
+    """
+    res = pretrained_clinc_service.query(text="hello there", n_neighbors=10)
+
+    assert res[0]["dist"] == 0.0
+    assert len(res) == 10
+
+    pretrained_clinc_service.save(tmpdir)
+
+    reloaded = Service.load(tmpdir)
+
+    assert reloaded._trained
+
+
+def test_smoke_encoded_clinc(encoded_clinc_service, tmpdir):
+    """
+    Run a simple smoke test to ensure that the service with a pretrained encoder is working.
+    """
+    encoded_data = encoded_clinc_service.encoder.transform(["hello there"])
+    res = encoded_clinc_service.query(data=encoded_data, n_neighbors=10)
+
+    assert res[0]["dist"] == 0.0
+    assert len(res) == 10
+
+    encoded_clinc_service.save(tmpdir)
+
+    reloaded = Service.load(tmpdir)
+
+    assert reloaded._trained
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -57,19 +57,3 @@ def test_smoke_pretrained_clinc(pretrained_clinc_service, tmpdir):
     assert reloaded._trained
 
 
-def test_smoke_encoded_clinc(encoded_clinc_service, tmpdir):
-    """
-    Run a simple smoke test to ensure that the service with a pretrained encoder is working.
-    """
-    encoded_data = encoded_clinc_service.encoder.transform(["hello there"])
-    res = encoded_clinc_service.query(data=encoded_data, n_neighbors=10)
-
-    assert res[0]["dist"] == 0.0
-    assert len(res) == 10
-
-    encoded_clinc_service.save(tmpdir)
-
-    reloaded = Service.load(tmpdir)
-
-    assert reloaded._trained
-


### PR DESCRIPTION
First of all this project looks great! I've taken an initial stab at #12 and also tried to add support querying data that has already been transformed. If you have data that you've already transformed (e.g. a UMAP embedding), you probably don't want to rerun encoder.transform again. In this case you want to index the transformed data and query it directly.

This is just a first crack so happy to incorporate any feedback you might have!